### PR TITLE
Add permission for teleport (1.12)

### DIFF
--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -2,6 +2,8 @@ package com.chaosthedude.naturescompass;
 
 import java.util.List;
 
+import net.minecraftforge.server.permission.DefaultPermissionLevel;
+import net.minecraftforge.server.permission.PermissionAPI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,6 +35,8 @@ public class NaturesCompass {
 	public static final String MODID = "naturescompass";
 	public static final String NAME = "Nature's Compass";
 	public static final String VERSION = "1.8.0";
+
+	public static final String TELEPORT_PERMISSION = "naturescompass.teleport";
 
 	public static final Logger logger = LogManager.getLogger(MODID);
 
@@ -68,6 +72,7 @@ public class NaturesCompass {
 	public void init(FMLInitializationEvent event) {
 		NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
 		allowedBiomes = BiomeUtils.getAllowedBiomes();
+		PermissionAPI.registerNode("naturescompass.teleport", DefaultPermissionLevel.OP, "Teleport permission of Nature's Compass");
 	}
 
 }

--- a/src/main/java/com/chaosthedude/naturescompass/util/PlayerUtils.java
+++ b/src/main/java/com/chaosthedude/naturescompass/util/PlayerUtils.java
@@ -1,15 +1,17 @@
 package com.chaosthedude.naturescompass.util;
 
+import com.chaosthedude.naturescompass.NaturesCompass;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.UserListOpsEntry;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.server.permission.PermissionAPI;
 
 public class PlayerUtils {
 	
 	public static boolean canTeleport(EntityPlayer player) {
-		return cheatModeEnabled(player) || isOp(player);
+		return cheatModeEnabled(player) || isOp(player) || hasPermission(player);
 	}
 
 	public static boolean cheatModeEnabled(EntityPlayer player) {
@@ -19,6 +21,10 @@ public class PlayerUtils {
 		}
 
 		return false;
+	}
+
+	public static boolean hasPermission(EntityPlayer player) {
+		return PermissionAPI.hasPermission(player, NaturesCompass.TELEPORT_PERMISSION);
 	}
 	
 	public static boolean isOp(EntityPlayer player) {


### PR DESCRIPTION
Adds another way to allow teleportation by adding the permission "naturescompass.teleport".
This is usefull for server owners that want to give teleportation rights to moderators or so without giving them OP