### PR TITLE
CI/CD for Natures compass 1.12.2

### DIFF
--- a/.github/workflows/autobuilds.yml
+++ b/.github/workflows/autobuilds.yml
@@ -26,7 +26,7 @@ jobs:
           find -type f -path './build/libs/*' -name '*sources*' -delete
       - uses: actions/upload-artifact@v2
         with:
-          name: Agricraft Build
+          name: NaturesCompass Build
           path: build/libs/*
   release:
     name: Create pubilc releases

--- a/.github/workflows/autobuilds.yml
+++ b/.github/workflows/autobuilds.yml
@@ -1,0 +1,48 @@
+name: Autobuild NaturesCompass
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Gradle build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: setupCIWorkspace build --no-daemon
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+      - name: Remove unneeded compiled files
+        run: |
+          find -type f -path './build/libs/*' -name '*sources*' -delete
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Agricraft Build
+          path: build/libs/*
+  release:
+    name: Create pubilc releases
+    runs-on: ubuntu-latest
+    needs: build
+    if: "startsWith(github.event.head_commit.message, 'Release')"
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v2
+      - name: Get version from commit
+        run: echo "VERSION=$(echo ${{ github.event.commits[0].message }} | awk '{print $2}')" >> $GITHUB_ENV 
+      - name: Release public builds
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.VERSION }}"
+          prerelease: true
+          draft: true
+          files: "**"


### PR DESCRIPTION
This pull makes it possible to create a jar based on each commit that's send to the 1.12.2 branch.
By commiting with the message: Release v1.2.3.whatever this CI/CD will create a release in the releases tab with the changelog from the previous version.
Filling in the comment/description field will make the release error out.

This pull has by default set that each Release will be a draft and a pre-release by default. If you wish i can change this behavior.

Each commit will have in this CI/CD a zip with the jars made.

Optional: This CI/CD can also be adjusted to run on pull_requests aswell. So you can quickly test a pull if it works etc.