### PR TITLE
fix(network): allow logging into servers that don't have the mod

### DIFF
--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -82,7 +82,11 @@ public class NaturesCompass {
 	}
 
 	private void preInit(FMLCommonSetupEvent event) {
-		network = ChannelBuilder.named(new ResourceLocation(NaturesCompass.MODID, NaturesCompass.MODID)).networkProtocolVersion(1).acceptedVersions(Channel.VersionTest.exact(1)).simpleChannel();
+		network = ChannelBuilder.named(new ResourceLocation(NaturesCompass.MODID, NaturesCompass.MODID))
+				.networkProtocolVersion(1)
+				.optionalServer()
+				.clientAcceptedVersions(Channel.VersionTest.exact(1))
+				.simpleChannel();
 
 		// Server packets
 		network.messageBuilder(CompassSearchPacket.class).encoder(CompassSearchPacket::toBytes).decoder(CompassSearchPacket::new).consumerMainThread(CompassSearchPacket::handle).add();


### PR DESCRIPTION
With the current networking setup players cannot login to any server that does not have NaturesCompass. 

This changes that to allow players to login to any server, but the server reject any client that does not have NaturesComapass