### PR TITLE
Fix not being able to connect to servers that don't have this mod installed.

### DIFF
--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -82,7 +82,7 @@ public class NaturesCompass {
 	}
 
 	private void preInit(FMLCommonSetupEvent event) {
-		network = ChannelBuilder.named(new ResourceLocation(NaturesCompass.MODID, NaturesCompass.MODID)).networkProtocolVersion(1).optionalServer().clientAcceptedVersions(Channel.VersionTest.exact(1)).simpleChannel();
+		network = ChannelBuilder.named(new ResourceLocation(NaturesCompass.MODID, NaturesCompass.MODID)).networkProtocolVersion(1).optionalClient().clientAcceptedVersions(Channel.VersionTest.exact(1)).simpleChannel();
 
 		// Server packets
 		network.messageBuilder(CompassSearchPacket.class).encoder(CompassSearchPacket::toBytes).decoder(CompassSearchPacket::new).consumerMainThread(CompassSearchPacket::handle).add();


### PR DESCRIPTION
A previous pull request #167 tried to fix this it seems but they called the wrong method.

optionalClient() is the correct method to call and I confirmed it with Lex from forge and ran my own tests to make sure:

Previous behavior (NaturesCompass-1.20.4-1.11.3-forge)
Modded Client -> Single player: Connected, Works.
Modded Client -> Vanilla Server: Connected, No functionality.
Modded Client -> (No mods) Forge Server: Rejected, 'mismatched mods'.
Modded Client -> Modded Forge Server: Connected, Works.
(No mods) Forge Client -> Modded Forge Server: Rejected, 'mismatched mods'.

New behavior
Modded Client -> Single player: Connected, Works.
Modded Client -> Vanilla Server: Connected, No functionality.
Modded Client -> (No mods) Forge Server: Connected, No functionality.
Modded Client -> Modded Forge Server: Connected, Works.
(No mods) Forge Client -> Modded Forge Server: Rejected, 'mismatched mods'.

The optionalServer() call from before was being overridden by the clientAcceptedVersions() call right after it so it didn't do any harm thankfully.

I'll be making the same PR to ExplorersCompass here in a minute, but I was also wondering if you could or would allow this to be back ported to 1.20.2? I'd be more then happy to make a PR for you if you'd like but I realize it might be less work on your part since its only a one line change, but I'd really a appreciate it as 1.20.2 is still the recommended forge and we have modpacks on Curse that use your mod that could benefit from this change. Thanks