### PR TITLE
Legacy 4J Crafting Support

### DIFF
--- a/src/main/resources/assets/naturescompass/crafting_tab_listing.json
+++ b/src/main/resources/assets/naturescompass/crafting_tab_listing.json
@@ -1,0 +1,7 @@
+{
+  "tools": {
+      "listing": {
+          "location": ["naturescompass:natures_compass"]
+      }
+  }
+}


### PR DESCRIPTION
Adds the crafting recipe to the Legacy 4J crafting interface. Doesn't modify any existing files, just adds the required JSON file to show the compass in Legacy 4J's crafting interface.