### PR TITLE
[1.21.5 Forge] Use context constructor param

### DIFF
--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -61,19 +61,19 @@ public class NaturesCompass {
 
 	public static NaturesCompass instance;
 
-	public NaturesCompass() {
+	public NaturesCompass(FMLJavaModLoadingContext context) {
 		instance = this;
 
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::preInit);
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::buildCreativeTabContents);
+		context.getModEventBus().addListener(NaturesCompass::preInit);
+		context.getModEventBus().addListener(NaturesCompass::buildCreativeTabContents);
 
-		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, ConfigHandler.GENERAL_SPEC);
-		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigHandler.CLIENT_SPEC);
+		context.registerConfig(ModConfig.Type.COMMON, ConfigHandler.GENERAL_SPEC);
+		context.registerConfig(ModConfig.Type.CLIENT, ConfigHandler.CLIENT_SPEC);
 
-		MinecraftForge.EVENT_BUS.register(this);
+		MinecraftForge.EVENT_BUS.addListener(NaturesCompass::registerNodes);
 	}
 
-	private void preInit(FMLCommonSetupEvent event) {
+	private static void preInit(FMLCommonSetupEvent event) {
 		network = ChannelBuilder.named(ResourceLocation.fromNamespaceAndPath(NaturesCompass.MODID, NaturesCompass.MODID)).networkProtocolVersion(1).optionalClient().clientAcceptedVersions(Channel.VersionTest.exact(1)).simpleChannel();
 
 		// Server packets
@@ -87,14 +87,13 @@ public class NaturesCompass {
 		dimensionKeysForAllowedBiomeKeys = ArrayListMultimap.create();
 	}
 
-	private void buildCreativeTabContents(BuildCreativeModeTabContentsEvent event) {
+	private static void buildCreativeTabContents(BuildCreativeModeTabContentsEvent event) {
 		if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
 			event.accept(new ItemStack(naturesCompass));
 		}
 	}
 
-	@SubscribeEvent
-	public void registerNodes(PermissionGatherEvent.Nodes event) {
+	public static void registerNodes(PermissionGatherEvent.Nodes event) {
 		event.addNodes(TELEPORT_PERMISSION);
 	}
 


### PR DESCRIPTION
Forge unified FMLJavaModLoadingContext and ModLoadingContext into one and deprecated the get() methods in favour of it being supplied to your mod's constructor as a parameter. Further details can be found [here](https://forums.minecraftforge.net/topic/154134-fresh-from-the-forge-2024/#comment-578201:~:text=Mod%20Registration%20Convenience%20Features).

This PR uses said feature to fix the deprecated usages in your mod.